### PR TITLE
Method renamed

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ const go = async () => {
     Network.enable()
   ])
 
-  await Network.enableRequestInterception({ enabled: true })
+  await Network.setRequestInterceptionEnabled({ enabled: true })
 
   await Page.navigate({ url: 'https://calibreapp.com' })
 


### PR DESCRIPTION
According to the [tip of tree CRI docs](https://chromedevtools.github.io/devtools-protocol/tot/Network/#method-setRequestInterceptionEnabled), `Network.enableRequestInterception` has been renamed to `Network.setRequestInterceptionEnabled`. 

Network request interception is still broken without the `--headless` flag (In Canary)